### PR TITLE
Update Burrow client constructor interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ go.work.sum
 
 .terraform
 .terraform.lock.hcl
+
+*.json

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ clean:
 	rm -rf dist
 
 TF_INIT_VARS=-backend-config=bucket=$(BUCKET_NAME) \
-	-backend-config=key=states/burrow/terraform.tfstate \
+	-backend-config=key=states/$(APP_NAME)/terraform.tfstate \
 	-backend-config=region=$(AWS_REGION)
 
 TF_VARS=-var name=$(APP_NAME) \
@@ -37,13 +37,13 @@ TF_VARS=-var name=$(APP_NAME) \
 .PHONY: deploy
 deploy: $(LAMBDA_BINARY)
 	cd terraform/main && \
-	terraform init $(TF_INIT_VARS) && \
+	terraform init $(TF_INIT_VARS) -reconfigure && \
 	terraform apply -auto-approve=$(AUTO_APPROVE) $(TF_VARS) && \
-	terraform output -json function_urls | jq > ../../function_urls.json
-	@echo "wrote function_urls.json"
+	terraform output -json function_urls | jq > ../../$(APP_NAME)-urls.json
+	@echo "wrote $(APP_NAME)-urls.json"
 
 .PHONY: destroy
 destroy: $(LAMBDA_BINARY)
 	cd terraform/main && \
-	terraform init $(TF_INIT_VARS) && \
+	terraform init $(TF_INIT_VARS) -reconfigure && \
 	terraform destroy -auto-approve=$(AUTO_APPROVE) $(TF_VARS)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add burrow package to your Go project:
 go get github.com/myzie/burrow
 ```
 
-Enable on an `http.Client`:
+Manually enable on an `http.Client`:
 
 ```go
 proxy := "https://randomprefix.lambda-url.eu-west-2.on.aws/"
@@ -69,14 +69,27 @@ client := &http.Client{
 // Client will now rotate through the provided proxies for each request
 ```
 
-Or use the `burrow.NewRoundRobinClient` helper:
+Or use the `burrow.NewClient` helper (recommended):
 
 ```go
-client := burrow.NewRoundRobinClient([]string{
-    "https://randomprefix1.lambda-url.us-east-1.on.aws/",
-    "https://randomprefix2.lambda-url.us-east-2.on.aws/",
-    "https://randomprefix3.lambda-url.us-west-1.on.aws/",
-})
+client := burrow.NewClient(
+    burrow.WithProxyURLs([]string{
+        "https://randomprefix1.lambda-url.us-east-1.on.aws/",
+        "https://randomprefix2.lambda-url.us-east-2.on.aws/",
+        "https://randomprefix3.lambda-url.us-west-1.on.aws/",
+    }),
+    burrow.WithRetries(3),
+    burrow.WithRetryableCodes([]int{429}),
+    burrow.WithTimeout(30 * time.Second),
+    burrow.WithMaxResponseBytes(10 * 1024 * 1024), // 10 MB
+    burrow.WithAllowedContentTypes([]string{
+        "application/json",
+        "text/plain",
+    }),
+    burrow.WithCallback(func(proxyURL string, attempt int, resp *http.Response) {
+        log.Printf("Request through %s succeeded on attempt %d", proxyURL, attempt)
+    }),
+)
 ```
 
 ## Multi-Region Deployment in AWS

--- a/client.go
+++ b/client.go
@@ -2,18 +2,8 @@ package burrow
 
 import (
 	"net/http"
+	"time"
 )
-
-// NewClient is a convenience function for creating an http.Client with a Burrow
-// Transport. If proxyURL is empty, the client will not use a proxy.
-func NewClient(proxyURL string) *http.Client {
-	if proxyURL == "" {
-		return &http.Client{}
-	}
-	return &http.Client{
-		Transport: NewTransport(proxyURL, "POST"),
-	}
-}
 
 // NewRoundRobinClient is a convenience function for creating an http.Client
 // with a RoundRobinTransport that rotates through the provided proxy URLs.
@@ -28,4 +18,111 @@ func NewRoundRobinClient(proxyURLs []string) *http.Client {
 	return &http.Client{
 		Transport: NewRoundRobinTransport(transports),
 	}
+}
+
+// ClientOption defines a function that configures a client
+type ClientOption func(*clientConfig)
+
+type clientConfig struct {
+	proxyURLs           []string
+	retries             int
+	retryableCodes      []int
+	callback            ProxyCallback
+	timeout             time.Duration
+	maxResponseBytes    int64
+	allowedContentTypes []string
+}
+
+// WithProxyURL sets a single proxy URL for the client
+func WithProxyURL(url string) ClientOption {
+	return func(c *clientConfig) {
+		c.proxyURLs = []string{url}
+	}
+}
+
+// WithProxyURLs sets the proxy URLs for the client
+func WithProxyURLs(urls []string) ClientOption {
+	return func(c *clientConfig) {
+		c.proxyURLs = urls
+	}
+}
+
+// WithRetries sets the number of retries for the client
+func WithRetries(retries int) ClientOption {
+	return func(c *clientConfig) {
+		c.retries = retries
+	}
+}
+
+// WithRetryableCodes sets the HTTP status codes that should trigger a retry
+func WithRetryableCodes(codes []int) ClientOption {
+	return func(c *clientConfig) {
+		c.retryableCodes = codes
+	}
+}
+
+// WithCallback sets a callback function that will be called each time a proxy
+// request has completed successfully.
+func WithCallback(callback ProxyCallback) ClientOption {
+	return func(c *clientConfig) {
+		c.callback = callback
+	}
+}
+
+// WithTimeout sets the timeout that is passed to the proxy
+func WithTimeout(timeout time.Duration) ClientOption {
+	return func(c *clientConfig) {
+		c.timeout = timeout
+	}
+}
+
+// WithMaxResponseBytes sets the maximum response body size
+func WithMaxResponseBytes(maxResponseBytes int64) ClientOption {
+	return func(c *clientConfig) {
+		c.maxResponseBytes = maxResponseBytes
+	}
+}
+
+// WithAllowedContentTypes sets the allowed content types
+func WithAllowedContentTypes(allowedContentTypes []string) ClientOption {
+	return func(c *clientConfig) {
+		c.allowedContentTypes = allowedContentTypes
+	}
+}
+
+// NewClient creates an http.Client with the provided Burrow options.
+// If no proxy URLs are provided, a vanilla http.Client is returned.
+func NewClient(opts ...ClientOption) *http.Client {
+	cfg := &clientConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	if len(cfg.proxyURLs) == 0 {
+		return &http.Client{}
+	}
+	var transports []http.RoundTripper
+	for _, proxyURL := range cfg.proxyURLs {
+		transport := NewTransport(proxyURL, "POST")
+		if cfg.callback != nil {
+			transport.WithCallback(cfg.callback)
+		}
+		if cfg.timeout > 0 {
+			transport.WithTimeout(cfg.timeout)
+		}
+		if cfg.maxResponseBytes > 0 {
+			transport.WithMaxResponseBytes(cfg.maxResponseBytes)
+		}
+		if len(cfg.allowedContentTypes) > 0 {
+			transport.WithAllowedContentTypes(cfg.allowedContentTypes)
+		}
+		transports = append(transports, transport)
+	}
+	rr := NewRoundRobinTransport(transports)
+	if cfg.retries > 0 {
+		rr.WithRetries(cfg.retries)
+	}
+	if cfg.retryableCodes != nil {
+		rr.WithRetryableCodes(cfg.retryableCodes)
+	}
+	return &http.Client{Transport: rr}
 }

--- a/cmd/example_client/main.go
+++ b/cmd/example_client/main.go
@@ -1,40 +1,81 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
+	"os"
+	"strings"
+	"time"
 
 	"github.com/myzie/burrow"
 )
 
 func main() {
+	var timeoutDur time.Duration
+	var maxResponseBytes, maxRetries int64
+	var allowedContentTypes string
 	var target, proxy, method string
 	flag.StringVar(&target, "url", "", "URL to send a request to")
 	flag.StringVar(&proxy, "proxy", "", "URL of the proxy to use")
+	flag.Int64Var(&maxResponseBytes, "max-response-bytes", 0, "Maximum response body size")
+	flag.DurationVar(&timeoutDur, "timeout", 0, "Timeout")
+	flag.Int64Var(&maxRetries, "retries", 0, "Maximum retries")
+	flag.StringVar(&allowedContentTypes, "allowed-content-types", "", "Allowed content types")
 	flag.Parse()
 
-	transport := burrow.NewTransport(proxy, "POST")
-	client := &http.Client{Transport: transport}
+	allowedContentTypesList := strings.Split(allowedContentTypes, ",")
+
+	opts := []burrow.ClientOption{
+		burrow.WithProxyURL(proxy),
+		burrow.WithRetries(int(maxRetries)),
+		burrow.WithRetryableCodes([]int{404}),
+		burrow.WithCallback(func(proxyResponse *burrow.Response) {
+			fmt.Printf("proxy response: %+v\n", proxyResponse)
+		}),
+	}
+	if maxResponseBytes > 0 {
+		opts = append(opts, burrow.WithMaxResponseBytes(maxResponseBytes))
+	}
+	if timeoutDur > 0 {
+		opts = append(opts, burrow.WithTimeout(timeoutDur))
+	}
+	if len(allowedContentTypesList) > 0 {
+		opts = append(opts, burrow.WithAllowedContentTypes(allowedContentTypesList))
+	}
+	client := burrow.NewClient(opts...)
+
 	req, err := http.NewRequest(method, target, nil)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Println("failed to create request:", err)
+		os.Exit(1)
 	}
+
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Fatal(err)
+		var proxyErr *burrow.ProxyError
+		if errors.As(err, &proxyErr) {
+			fmt.Println("proxy error:", proxyErr.Message)
+			fmt.Println("proxy error type:", proxyErr.Type)
+			os.Exit(1)
+		}
+		fmt.Println("unknown error:", err)
+		os.Exit(1)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		log.Fatalf("unexpected status code: %d", resp.StatusCode)
+		fmt.Printf("unexpected status code: %d\n", resp.StatusCode)
+		os.Exit(1)
 	}
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Println("failed to read response body:", err)
+		os.Exit(1)
 	}
+
+	fmt.Println("================")
 	fmt.Println(string(body))
 }

--- a/cmd/lambda/main.go
+++ b/cmd/lambda/main.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
+	"fmt"
+	"log/slog"
+	"os"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -13,55 +15,114 @@ import (
 
 type RequestHandler struct {
 	Burrow burrow.Handler
+	Logger *slog.Logger
 }
 
 func (h RequestHandler) Handle(ctx context.Context, request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
 	var burrowReq burrow.Request
 	if err := json.Unmarshal([]byte(request.Body), &burrowReq); err != nil {
-		return NewErrorResponse(400, err), nil
+		return NewGenericErrorResponse(400, fmt.Errorf("invalid request body (expected json)")), nil
 	}
-	log.Println("burrow url:", burrowReq.URL)
-	log.Println("client source ip:", request.RequestContext.HTTP.SourceIP)
-	log.Println("client user agent:", request.RequestContext.HTTP.UserAgent)
+	if burrowReq.Method == "" {
+		burrowReq.Method = "GET"
+	}
+	proxyName := fmt.Sprintf("aws.lambda.%s", getRegion())
 
-	burrowRes, err := h.Burrow(ctx, &burrowReq)
+	h.Logger.Info("request received",
+		"proxy_name", proxyName,
+		"url", burrowReq.URL,
+		"method", burrowReq.Method,
+		"timeout", burrowReq.Timeout,
+		"max_response_bytes", burrowReq.MaxResponseBytes,
+		"allowed_content_types", burrowReq.AllowedContentTypes,
+		"client_ip", request.RequestContext.HTTP.SourceIP,
+		"user_agent", request.RequestContext.HTTP.UserAgent)
+
+	response, err := h.Burrow(ctx, &burrowReq)
 	if err != nil {
-		if errors.Is(err, &burrow.BadInputError{}) {
-			log.Println("bad input error:", err.Error())
-			return NewErrorResponse(400, err), nil
+		var proxyErr *burrow.ProxyError
+		if errors.As(err, &proxyErr) {
+			h.Logger.Error("proxy error", "error", err)
+			return NewProxyErrorResponse(proxyErr), nil
 		}
-		log.Println("failed to handle request:", err)
-		return NewErrorResponse(500, err), nil
+		h.Logger.Error("unknown error", "error", err)
+		return NewGenericErrorResponse(500, err), nil
 	}
 
-	burrowRes.ClientDetails = &burrow.ClientDetails{
+	response.ClientDetails = &burrow.ClientDetails{
 		SourceIP:  request.RequestContext.HTTP.SourceIP,
 		UserAgent: request.RequestContext.HTTP.UserAgent,
 	}
-
-	responseBody, err := json.Marshal(burrowRes)
+	response.ProxyName = proxyName
+	responseBody, err := json.Marshal(response)
 	if err != nil {
-		log.Println("failed to marshal response:", err)
-		return NewErrorResponse(500, err), nil
+		h.Logger.Error("marshalling error", "error", err)
+		return NewGenericErrorResponse(500, err), nil
 	}
-	log.Println("burrow success to:", burrowReq.URL)
-	log.Println("burrow status code:", burrowRes.StatusCode)
+
+	h.Logger.Info("request completed",
+		"proxy_name", proxyName,
+		"url", burrowReq.URL,
+		"method", burrowReq.Method,
+		"duration", response.Duration,
+		"status_code", response.StatusCode,
+		"body_size", len(responseBody),
+		"content_type", response.Headers["Content-Type"])
 
 	return events.APIGatewayV2HTTPResponse{
 		StatusCode: 200,
 		Body:       string(responseBody),
+		Headers:    map[string]string{"Content-Type": "application/json"},
 	}, nil
 }
 
-func NewErrorResponse(statusCode int, err error) events.APIGatewayV2HTTPResponse {
+func NewGenericErrorResponse(statusCode int, err error) events.APIGatewayV2HTTPResponse {
+	body, err := json.Marshal(map[string]string{"message": err.Error()})
+	if err != nil {
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: statusCode,
+			Body:       err.Error(),
+			Headers:    map[string]string{"Content-Type": "text/plain"},
+		}
+	}
 	return events.APIGatewayV2HTTPResponse{
 		StatusCode: statusCode,
-		Body:       err.Error(),
-		Headers:    map[string]string{"Content-Type": "text/plain"},
+		Body:       string(body),
+		Headers:    map[string]string{"Content-Type": "application/json"},
 	}
 }
 
+func NewProxyErrorResponse(proxyErr *burrow.ProxyError) events.APIGatewayV2HTTPResponse {
+	statusCode := 500
+	if proxyErr.Type == burrow.ProxyErrBadRequest {
+		statusCode = 400
+	}
+	proxyErrBody, err := json.Marshal(proxyErr)
+	if err != nil {
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: statusCode,
+			Body:       fmt.Sprintf(`{"message": "marshalling error: %s"}`, err.Error()),
+			Headers:    map[string]string{"Content-Type": "application/json"},
+		}
+	}
+	return events.APIGatewayV2HTTPResponse{
+		StatusCode: statusCode,
+		Body:       string(proxyErrBody),
+		Headers:    map[string]string{"Content-Type": "application/json"},
+	}
+}
+
+func getRegion() string {
+	if region := os.Getenv("AWS_REGION"); region != "" {
+		return region
+	}
+	return os.Getenv("AWS_DEFAULT_REGION")
+}
+
 func main() {
-	h := RequestHandler{Burrow: burrow.GetHandler()}
+	h := RequestHandler{
+		Burrow: burrow.GetHandler(),
+		Logger: slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+	}
 	lambda.Start(h.Handle)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/myzie/burrow
 
 go 1.22.2
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/requests.go
+++ b/requests.go
@@ -10,11 +10,14 @@ import (
 
 // Request represents an http request in a format that can be easily serialized
 type Request struct {
-	URL     string            `json:"url"`
-	Method  string            `json:"method,omitempty"`
-	Headers map[string]string `json:"headers,omitempty"`
-	Body    string            `json:"body,omitempty"`
-	Cookies []string          `json:"cookies,omitempty"`
+	URL                 string            `json:"url"`
+	Method              string            `json:"method,omitempty"`
+	Headers             map[string]string `json:"headers,omitempty"`
+	Body                string            `json:"body,omitempty"`
+	Cookies             string            `json:"cookies,omitempty"`
+	Timeout             float64           `json:"timeout,omitempty"`
+	MaxResponseBytes    int64             `json:"max_response_bytes,omitempty"`
+	AllowedContentTypes []string          `json:"allowed_content_types,omitempty"`
 }
 
 // Response represents an http response in a format that can be easily deserialized
@@ -22,8 +25,9 @@ type Response struct {
 	StatusCode    int               `json:"status_code"`
 	Headers       map[string]string `json:"headers,omitempty"`
 	Body          string            `json:"body,omitempty"`
-	Cookies       []string          `json:"cookies,omitempty"`
 	ClientDetails *ClientDetails    `json:"client_details,omitempty"`
+	Duration      float64           `json:"duration,omitempty"`
+	ProxyName     string            `json:"proxy_name,omitempty"`
 }
 
 // ClientDetails represents the details of the client that made the request

--- a/server.go
+++ b/server.go
@@ -5,9 +5,27 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
+	"time"
 )
+
+var defaultMaxRedirects = 5
+
+var defaultMaxResponseBytes = int64(5 * 1024 * 1024) // 5MB default
+
+var defaultTransport = &http.Transport{
+	DialContext: (&net.Dialer{
+		Timeout:   5 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).DialContext,
+	TLSHandshakeTimeout:   5 * time.Second,
+	ResponseHeaderTimeout: 10 * time.Second,
+	MaxIdleConns:          100,
+	MaxIdleConnsPerHost:   10,
+	IdleConnTimeout:       90 * time.Second,
+}
 
 // Handler is a function used to process Burrow HTTP proxy requests.
 type Handler func(ctx context.Context, req *Request) (*Response, error)
@@ -18,11 +36,25 @@ func GetHandler(c ...*http.Client) Handler {
 	if len(c) > 0 {
 		client = c[0]
 	} else {
-		client = &http.Client{}
+		client = &http.Client{
+			Transport: defaultTransport,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if len(via) >= defaultMaxRedirects {
+					return fmt.Errorf("stopped after %d redirects", len(via))
+				}
+				return nil
+			},
+		}
 	}
 	return func(ctx context.Context, req *Request) (*Response, error) {
 		if req.URL == "" {
-			return nil, &BadInputError{Err: fmt.Errorf("url is required")}
+			return nil, ProxyErrorf(ProxyErrBadRequest, "url is required")
+		}
+		start := time.Now()
+		if req.Timeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, time.Duration(req.Timeout*float64(time.Second)))
+			defer cancel()
 		}
 		method := "GET"
 		if req.Method != "" {
@@ -33,29 +65,50 @@ func GetHandler(c ...*http.Client) Handler {
 			var err error
 			decodedBody, err = base64.StdEncoding.DecodeString(req.Body)
 			if err != nil {
-				return nil, &BadInputError{
-					Err: fmt.Errorf("failed to decode request body: %w", err),
-				}
+				return nil, ProxyErrorf(ProxyErrBadRequest, "failed to decode request body: %v", err)
 			}
 		}
-		httpReq, err := http.NewRequestWithContext(ctx, method, req.URL,
-			strings.NewReader(string(decodedBody)))
+		httpReqBody := strings.NewReader(string(decodedBody))
+		httpReq, err := http.NewRequestWithContext(ctx, method, req.URL, httpReqBody)
 		if err != nil {
-			return nil, &BadInputError{
-				Err: fmt.Errorf("failed to create http request: %w", err),
-			}
+			return nil, ProxyErrorf(ProxyErrBadRequest, "failed to create http request: %v", err)
 		}
 		for k, v := range req.Headers {
 			httpReq.Header.Set(k, v)
 		}
+		if req.Cookies != "" {
+			httpReq.Header.Add("Cookie", req.Cookies)
+		}
 		resp, err := client.Do(httpReq)
 		if err != nil {
-			return nil, fmt.Errorf("failed to perform http request: %w", err)
+			if isTimeoutError(err) {
+				return nil, ProxyErrorf(ProxyErrTimeout, "http request timed out")
+			}
+			return nil, ProxyErrorf(ProxyErrUnknown, "failed to execute http request: %v", err)
 		}
 		defer resp.Body.Close()
-		body, err := io.ReadAll(resp.Body)
+
+		if len(req.AllowedContentTypes) > 0 {
+			contentType := resp.Header.Get("Content-Type")
+			if !isContentTypeAllowed(contentType, req.AllowedContentTypes) {
+				return nil, ProxyErrorf(ProxyErrDisallowedContentType, "response content type is disallowed: %s", contentType)
+			}
+		}
+		maxSize := defaultMaxResponseBytes
+		if req.MaxResponseBytes > 0 {
+			maxSize = req.MaxResponseBytes
+		}
+		// Add 1 so that we can detect if the body was truncated
+		limitReader := io.LimitReader(resp.Body, maxSize+1)
+		body, err := io.ReadAll(limitReader)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read response body: %w", err)
+			if isTimeoutError(err) {
+				return nil, ProxyErrorf(ProxyErrTimeout, "response body read timed out")
+			}
+			return nil, ProxyErrorf(ProxyErrUnknown, "failed to read response body: %v", err)
+		}
+		if int64(len(body)) > maxSize {
+			return nil, ProxyErrorf(ProxyErrExceededMaxBodySize, "response body exceeded maximum size: %d", maxSize)
 		}
 		var encodedBody string
 		if len(body) > 0 {
@@ -69,18 +122,26 @@ func GetHandler(c ...*http.Client) Handler {
 			StatusCode: resp.StatusCode,
 			Headers:    headers,
 			Body:       encodedBody,
+			Duration:   time.Since(start).Seconds(),
 		}, nil
 	}
 }
 
-type BadInputError struct {
-	Err error
+func isContentTypeAllowed(contentType string, allowedContentTypes []string) bool {
+	for _, allowedContentType := range allowedContentTypes {
+		if strings.HasPrefix(contentType, allowedContentType) {
+			return true
+		}
+	}
+	return false
 }
 
-func (b *BadInputError) Error() string {
-	return fmt.Sprintf("bad input: %v", b.Err)
-}
-
-func (b *BadInputError) Unwrap() error {
-	return b.Err
+func isTimeoutError(err error) bool {
+	if netErr, ok := err.(net.Error); ok {
+		return netErr.Timeout()
+	}
+	if err == context.DeadlineExceeded {
+		return true
+	}
+	return false
 }

--- a/transport_http.go
+++ b/transport_http.go
@@ -6,16 +6,51 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 )
 
 var _ http.RoundTripper = &Transport{}
 
+type ErrorCode int
+
+const (
+	ProxyErrUnknown               ErrorCode = 0
+	ProxyErrBadRequest            ErrorCode = 1
+	ProxyErrExceededMaxBodySize   ErrorCode = 2
+	ProxyErrDisallowedContentType ErrorCode = 3
+	ProxyErrTimeout               ErrorCode = 4
+)
+
+type ProxyError struct {
+	Message string    `json:"message"`
+	Type    ErrorCode `json:"type"`
+}
+
+func (e *ProxyError) Error() string {
+	return fmt.Sprintf("proxy error [%d] %s", e.Type, e.Message)
+}
+
+func ProxyErrorf(code ErrorCode, format string, args ...any) *ProxyError {
+	return &ProxyError{
+		Type:    code,
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+
+// ProxyCallback is a callback function that will be called each time a proxy
+// request has completed successfully.
+type ProxyCallback func(proxyResponse *Response)
+
 // Transport implements the http.RoundTripper interface. Used to proxy HTTP
 // requests via a Burrow HTTP endpoint.
 type Transport struct {
-	proxyURL string
-	method   string
-	client   *http.Client
+	proxyURL            string
+	method              string
+	client              *http.Client
+	callback            ProxyCallback
+	timeout             time.Duration
+	maxResponseBytes    int64
+	allowedContentTypes []string
 }
 
 // RoundTrip implements the http.RoundTripper interface
@@ -24,12 +59,14 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize request: %w", err)
 	}
+	serReq.Timeout = t.timeout.Seconds()
+	serReq.MaxResponseBytes = t.maxResponseBytes
+	serReq.AllowedContentTypes = t.allowedContentTypes
 	payload, err := json.Marshal(serReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
-	proxyReq, err := http.NewRequestWithContext(req.Context(), t.method, t.proxyURL,
-		bytes.NewReader(payload))
+	proxyReq, err := http.NewRequestWithContext(req.Context(), t.method, t.proxyURL, bytes.NewReader(payload))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create proxy request: %w", err)
 	}
@@ -39,16 +76,26 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, fmt.Errorf("failed to send request to proxy: %w", err)
 	}
 	defer proxyResp.Body.Close()
-	if proxyResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("proxy returned non-200 status code: %d", proxyResp.StatusCode)
-	}
 	body, err := io.ReadAll(proxyResp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read proxy response body: %w", err)
 	}
+	if proxyResp.StatusCode != http.StatusOK {
+		var errResp ProxyError
+		if err := json.Unmarshal(body, &errResp); err != nil {
+			return nil, &ProxyError{
+				Message: fmt.Sprintf("proxy returned non-200 status code: %d", proxyResp.StatusCode),
+				Type:    ProxyErrUnknown,
+			}
+		}
+		return nil, &errResp
+	}
 	var serResp Response
 	if err := json.Unmarshal(body, &serResp); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	if t.callback != nil {
+		t.callback(&serResp)
 	}
 	return DeserializeResponse(&serResp)
 }
@@ -70,4 +117,29 @@ func NewTransportWithClient(proxyURL string, method string, c *http.Client) *Tra
 		method:   method,
 		client:   c,
 	}
+}
+
+// WithCallback sets a callback function that will be called each time a proxy
+// request has completed successfully.
+func (t *Transport) WithCallback(callback ProxyCallback) *Transport {
+	t.callback = callback
+	return t
+}
+
+// WithTimeout sets the timeout that is passed to the proxy
+func (t *Transport) WithTimeout(timeout time.Duration) *Transport {
+	t.timeout = timeout
+	return t
+}
+
+// WithMaxResponseBytes sets the maximum response body size
+func (t *Transport) WithMaxResponseBytes(maxResponseBytes int64) *Transport {
+	t.maxResponseBytes = maxResponseBytes
+	return t
+}
+
+// WithAllowedContentTypes sets the allowed content types
+func (t *Transport) WithAllowedContentTypes(allowedContentTypes []string) *Transport {
+	t.allowedContentTypes = allowedContentTypes
+	return t
 }

--- a/transport_http_test.go
+++ b/transport_http_test.go
@@ -1,0 +1,122 @@
+package burrow
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransport_RoundTrip(t *testing.T) {
+	successEncoded := base64.StdEncoding.EncodeToString([]byte("success"))
+	tests := []struct {
+		name           string
+		setupMockProxy func() *httptest.Server
+		setupTransport func(*Transport)
+		inputURL       string
+		expectedErr    string
+	}{
+		{
+			name: "successful request",
+			setupMockProxy: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+					json.NewEncoder(w).Encode(Response{
+						StatusCode: 200,
+						Headers:    map[string]string{"Content-Type": "text/plain"},
+						Body:       successEncoded,
+					})
+				}))
+			},
+			inputURL: "https://example.com",
+		},
+		{
+			name: "proxy returns error",
+			setupMockProxy: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusBadRequest)
+					json.NewEncoder(w).Encode(ProxyError{
+						Message: "bad request",
+						Type:    ProxyErrBadRequest,
+					})
+				}))
+			},
+			inputURL:    "https://example.com",
+			expectedErr: "proxy error [1] bad request",
+		},
+		{
+			name: "respects timeout",
+			setupMockProxy: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// Decode the incoming request to verify timeout was set
+					var serReq Request
+					json.NewDecoder(r.Body).Decode(&serReq)
+					assert.Equal(t, float64(2), serReq.Timeout)
+					resp := Response{
+						StatusCode: 200,
+						Body:       successEncoded,
+					}
+					json.NewEncoder(w).Encode(resp)
+				}))
+			},
+			setupTransport: func(t *Transport) {
+				t.WithTimeout(2 * time.Second)
+			},
+			inputURL: "https://example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockProxy := tt.setupMockProxy()
+			defer mockProxy.Close()
+
+			transport := NewTransport(mockProxy.URL, "POST")
+			if tt.setupTransport != nil {
+				tt.setupTransport(transport)
+			}
+			req, err := http.NewRequest("GET", tt.inputURL, nil)
+			require.NoError(t, err)
+			resp, err := transport.RoundTrip(req)
+			if tt.expectedErr != "" {
+				assert.EqualError(t, err, tt.expectedErr)
+				assert.Nil(t, resp)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, resp)
+			}
+		})
+	}
+}
+
+func TestTransportBuilders(t *testing.T) {
+	transport := NewTransport("http://proxy", "POST")
+
+	callback := func(r *Response) {}
+	transport.WithCallback(callback)
+	assert.NotNil(t, transport.callback)
+
+	transport.WithTimeout(5 * time.Second)
+	assert.Equal(t, 5*time.Second, transport.timeout)
+
+	transport.WithMaxResponseBytes(1000)
+	assert.Equal(t, int64(1000), transport.maxResponseBytes)
+
+	allowedTypes := []string{"application/json"}
+	transport.WithAllowedContentTypes(allowedTypes)
+	assert.Equal(t, allowedTypes, transport.allowedContentTypes)
+}
+
+func TestNewTransportWithClient(t *testing.T) {
+	customClient := &http.Client{Timeout: 5 * time.Second}
+	transport := NewTransportWithClient("http://proxy", "POST", customClient)
+
+	assert.Equal(t, customClient, transport.client)
+	assert.Equal(t, "http://proxy", transport.proxyURL)
+	assert.Equal(t, "POST", transport.method)
+}

--- a/transport_roundrobin.go
+++ b/transport_roundrobin.go
@@ -1,8 +1,12 @@
 package burrow
 
 import (
+	"bytes"
+	"io"
+	"math"
 	"net/http"
 	"sync"
+	"time"
 )
 
 var _ http.RoundTripper = &RoundRobinTransport{}
@@ -13,21 +17,111 @@ type RoundRobinTransport struct {
 	transports []http.RoundTripper
 	mutex      sync.Mutex
 	index      int
+	retries    int
+	retryable  map[int]bool
 }
 
 // NewRoundRobinTransport creates a new RoundRobinTransport that rotates through
 // the provided http.Transports with each request.
 func NewRoundRobinTransport(transports []http.RoundTripper) *RoundRobinTransport {
-	return &RoundRobinTransport{transports: transports}
+	return &RoundRobinTransport{
+		transports: transports,
+		retryable:  defaultRetryableCodes,
+	}
 }
 
-// RoundTrip implements the http.RoundTripper interface
-func (r *RoundRobinTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	r.mutex.Lock()
-	index := r.index
-	r.index = (r.index + 1) % len(r.transports)
-	transport := r.transports[index]
-	r.mutex.Unlock()
+// WithRetries sets the allowed number of retry attempts for each request.
+func (r *RoundRobinTransport) WithRetries(retries int) *RoundRobinTransport {
+	if retries < 0 {
+		retries = 0
+	}
+	r.retries = retries
+	return r
+}
 
-	return transport.RoundTrip(req)
+// WithRetryableCodes sets the list of HTTP status codes that should be retried.
+func (r *RoundRobinTransport) WithRetryableCodes(codes []int) *RoundRobinTransport {
+	retryable := map[int]bool{}
+	for _, code := range codes {
+		retryable[code] = true
+	}
+	r.retryable = retryable
+	return r
+}
+
+// RoundTrip implements the http.RoundTripper interface.
+func (r *RoundRobinTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone the request body if it exists
+	var bodyBytes []byte
+	if req.Body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		req.Body.Close()
+	}
+	var lastResp *http.Response
+	for i := 0; i <= r.retries; i++ {
+		// Recreate the body for each attempt
+		if bodyBytes != nil {
+			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		}
+		transport := r.nextTransport()
+		response, err := transport.RoundTrip(req)
+		if err != nil {
+			// This means the proxying itself failed, which we will not retry
+			return nil, err
+		}
+		// Return immediately if the status code is in the 2xx range
+		if response.StatusCode >= 200 && response.StatusCode < 300 {
+			return response, nil
+		}
+		// Return immediately if the status code is not retryable
+		if !r.isRetryable(response.StatusCode) {
+			return response, nil
+		}
+		// Close the response body if we're not returning it
+		if lastResp != nil {
+			lastResp.Body.Close()
+		}
+		lastResp = response
+
+		// Skip sleep on the last iteration
+		if i < r.retries {
+			// Calculate backoff duration starting from 100ms
+			backoff := time.Duration(math.Pow(2, float64(i))*100) * time.Millisecond
+			// Use context-aware sleep
+			timer := time.NewTimer(backoff)
+			select {
+			case <-req.Context().Done():
+				timer.Stop()
+				return lastResp, req.Context().Err()
+			case <-timer.C:
+				// Continue with next retry
+			}
+		}
+	}
+	return lastResp, nil
+}
+
+func (r *RoundRobinTransport) nextTransport() http.RoundTripper {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	transport := r.transports[r.index]
+	r.index = (r.index + 1) % len(r.transports)
+	return transport
+}
+
+func (r *RoundRobinTransport) isRetryable(code int) bool {
+	return r.retryable[code]
+}
+
+var defaultRetryableCodes = map[int]bool{
+	http.StatusTooManyRequests:    true,
+	http.StatusRequestTimeout:     true,
+	http.StatusServiceUnavailable: true,
+	http.StatusGatewayTimeout:     true,
+	http.StatusBadGateway:         true,
+	999:                           true,
 }


### PR DESCRIPTION
As documented in the readme, the new client initialization looks like this:

```go
client := burrow.NewClient(
    burrow.WithProxyURLs([]string{
        "https://randomprefix1.lambda-url.us-east-1.on.aws/",
        "https://randomprefix2.lambda-url.us-east-2.on.aws/",
        "https://randomprefix3.lambda-url.us-west-1.on.aws/",
    }),
    burrow.WithRetries(3),
    burrow.WithRetryableCodes([]int{429}),
    burrow.WithTimeout(30 * time.Second),
    burrow.WithMaxResponseBytes(10 * 1024 * 1024), // 10 MB
    burrow.WithAllowedContentTypes([]string{
        "application/json",
        "text/plain",
    }),
    burrow.WithCallback(func(proxyURL string, attempt int, resp *http.Response) {
        log.Printf("Request through %s succeeded on attempt %d", proxyURL, attempt)
    }),
)
```

This PR adds the retry, timeout, max response bytes, allowed content types, and callback functionality.